### PR TITLE
Move classnames from devDeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
-    "classnames": "^2.2.5",
     "cpy": "^3.4.1",
     "css-loader": "0.24.0",
     "file-loader": "0.9.0",
@@ -42,6 +41,7 @@
     "webpack-hot-middleware": "^2.12.2"
   },
   "dependencies": {
+    "classnames": "^2.2.5",
     "react": "^15.3.2",
     "react-dom": "^15.3.2"
   },


### PR DESCRIPTION
This is used in the source code so it should be in `dependencies` to ensure npm installs it when appropriate. Thanks!