### PR TITLE
Move React addons from devdeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "css-loader": "0.24.0",
     "file-loader": "0.9.0",
     "nib": "^1.1.2",
-    "react-addons-shallow-compare": "^15.3.1",
-    "react-addons-update": "^15.3.2",
     "rimraf": "2.5.4",
     "stylus": "^0.54.5",
     "style-loader": "0.13.1",
@@ -43,7 +41,9 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "react": "^15.3.2",
-    "react-dom": "^15.3.2"
+    "react-dom": "^15.3.2",
+    "react-addons-shallow-compare": "^15.3.1",
+    "react-addons-update": "^15.3.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi,

The react-nestable NPM package was not working out of the box for me because some React addons were listed as dev dependencies instead of normal dependencies so they were not automatically installed.